### PR TITLE
Fix: use log_softmax on logits before computing sequence scores

### DIFF
--- a/examples/PPO_LoRA_finetuning/main.py
+++ b/examples/PPO_LoRA_finetuning/main.py
@@ -58,19 +58,20 @@ class LogScoringModuleFn(BaseModuleFunction):
             logits = forward_outputs["logits"][:, :-1, :]  # skip </s> token appended by tokenizer
             output_tokens = minibatch["decoder_input_ids"][:, 1:]  # skip pad token
 
+        logprobs = torch.log_softmax(logits, dim=-1) # convert logits to log-probabilities
         tokens_logprobs = \
-            torch.gather(logits, 2, output_tokens[:, :, None]).squeeze(-1).to(torch.float32)  # filter with sequence tokens
+            torch.gather(logprobs, 2, output_tokens[:, :, None]).squeeze(-1).to(torch.float32)  # filter with sequence tokens
 
-        # Compute mask to assign probability 1 to padding tokens
+        # Compute mask to assign log-probability 0 to padding tokens
         mask = torch.ones(tokens_logprobs.shape, dtype=torch.bool, device=self.device)
         for i, _output in enumerate(output_tokens):
             for j, _token in enumerate(_output):
                 if _token != self._pad_token:
                     mask[i, j] = False
-        masked_token_probs = tokens_logprobs.masked_fill(mask, 0.0)  # apply mask
-        minibatch_probs = masked_token_probs.sum(-1)  # compute final sequences' probability
+        masked_token_logprobs = tokens_logprobs.masked_fill(mask, 0.0)  # apply mask
+        minibatch_logprobs = masked_token_logprobs.sum(-1)  # compute final sequences' log-probabilities
 
-        return minibatch_probs.cpu()
+        return minibatch_logprobs.cpu()
 
 class ValueHeadModuleFn(BaseModuleFunction):
     def __init__(self, model_type, pre_encoded_input):

--- a/examples/PPO_finetuning/main.py
+++ b/examples/PPO_finetuning/main.py
@@ -56,19 +56,20 @@ class LogScoringModuleFn(BaseModuleFunction):
             logits = forward_outputs["logits"][:, :-1, :]  # skip </s> token appended by tokenizer
             output_tokens = minibatch["decoder_input_ids"][:, 1:]  # skip pad token
 
+        logprobs = torch.log_softmax(logits, dim=-1) # convert logits to log-probabilities
         tokens_logprobs = \
-            torch.gather(logits, 2, output_tokens[:, :, None]).squeeze(-1).to(torch.float32)  # filter with sequence tokens
+            torch.gather(logprobs, 2, output_tokens[:, :, None]).squeeze(-1).to(torch.float32)  # filter with sequence tokens
 
-        # Compute mask to assign probability 1 to padding tokens
+        # Compute mask to assign log-probability 0 to padding tokens
         mask = torch.ones(tokens_logprobs.shape, dtype=torch.bool, device=self.device)
         for i, _output in enumerate(output_tokens):
             for j, _token in enumerate(_output):
                 if _token != self._pad_token:
                     mask[i, j] = False
-        masked_token_probs = tokens_logprobs.masked_fill(mask, 0.0)  # apply mask
-        minibatch_probs = masked_token_probs.sum(-1)  # compute final sequences' probability
+        masked_token_logprobs = tokens_logprobs.masked_fill(mask, 0.0)  # apply mask
+        minibatch_logprobs = masked_token_logprobs.sum(-1)  # compute final sequences' log-probabilities
 
-        return minibatch_probs.cpu()
+        return minibatch_logprobs.cpu()
 
 class ValueHeadModuleFn(BaseModuleFunction):
     def __init__(self, model_type, pre_encoded_input):


### PR DESCRIPTION
This PR converts the logits to log-probabilities using `log_softmax` along the vocabulary dimension. This fixes scoring inconsistencies that could rank sequences incorrectly.

Previously, the `LogScoringModuleFn` class used raw logits to compute sequence scores. Since the logits are not normalized, summing them does not produce meaningful scoring.


### Sequence scoring: logits vs. log-probabilities

Let a language model output logits over a vocabulary of size $V$. Denote $z_i(t)$  as the logit for token $t$ at position $i$ in a candidate sequence $(t_1, t_2, \dots, t_n)$.

#### Summing logits: 

$$
S_\text{logits} = \sum_{i=1}^{n} z_i(t_i)
$$

#### Summing log-probabilities: 

$$
p_i(t_i) = \frac{e^{z_i(t_i)}}{\sum_{v=1}^{V} e^{z_i(v)}},\quad S_\text{logprobs} = \log p(t_1, t_2, \dots, t_n) = \sum_{i=1}^{n} \log p_i(t_i) 
= \sum_{i=1}^{n} \Big( z_i(t_i) - \log \sum_{v=1}^{V} e^{z_i(v)} \Big)
$$

The normalization term $-\log \sum_{v=1}^{V} e^{z_i(v)}$ depends on the logits of all tokens at each position and it adjusts for how confident the distribution is.

### Impact on GLAM framework:

<p align="center">
  <img width="589" alt="heb" src="https://github.com/user-attachments/assets/220f161e-a39a-4a96-a263-9d23a423a1e8" />
</p>

The results show that using sum of raw logits prevents the model from correctly selecting optimal action candidates. 

#### Numerical example from the experiment:

For a given prompt and two candidate actions, "go forward" and "pick up", the logits and log-probabilities are:


<div align="center">

<table>
  <tr>
    <th>Action</th>
    <th>Token logits</th>
    <th>Token logprobs</th>
    <th>Sum logits</th>
    <th>Sum logprobs</th>
  </tr>
  <tr>
    <td>go forward</td>
    <td>[25.99, 46.38]</td>
    <td>[-0.48, 0.00]</td>
    <td>72.37</td>
    <td>-0.48</td>
  </tr>
  <tr>
    <td>pick up</td>
    <td>[16.95, 104.55]</td>
    <td>[-9.53, 0.00]</td>
    <td>121.50</td>
    <td>-9.53</td>
  </tr>
</table>

</div>

When summing logits, "pick up" is always selected because the high logit of token "up" dominates the score. Whereas in summing log-probabilities, it has 0 value and reflects its contribution.